### PR TITLE
Add try in date function. Not more warning

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -427,7 +427,7 @@
 				</div>
 				<footer>
 					<ul id="copyright">
-						<li>&copy; <?php echo date('Y'); ?> PHPWomen</li>
+						<li>&copy; <?php echo @date('Y'); ?> PHPWomen</li>
 						<li>Design: <a href="http://html5up.net/">HTML5 UP</a></li>
 					</ul>
 				</footer>


### PR DESCRIPTION
Warning: date(): It is not safe to rely on the system's timezone settings. You are _required_ to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone. in front-page.php on line 430
- Add @date()
